### PR TITLE
Fix 32-bit MinGW-w64 compilation

### DIFF
--- a/include/FastNoise/Generators/Utils.inl
+++ b/include/FastNoise/Generators/Utils.inl
@@ -30,7 +30,7 @@ namespace FastNoise
             int32v index = FS_Convertf32_i32( FS_Converti32_f32( hash & int32v( 0x3FFFFF ) ) * float32v( 1.3333333333333333f ) );
 
             // Bit-4 = Choose X Y ordering
-            mask32v xy = index << 29;
+            mask32v xy = mask32v( index ) << 29;
 
             if constexpr( FS::SIMD_Level > FastSIMD::Level_Scalar && FS::SIMD_Level < FastSIMD::Level_SSE41 )
             {
@@ -44,7 +44,7 @@ namespace FastNoise
             b ^= FS_Casti32_f32( index << 31 );
 
             // Bit-2 = Mul a by 2 or Root3
-            mask32v aMul2 = (index << 30) >> 31;
+            mask32v aMul2 = (mask32v( index ) << 30) >> 31;
             a *= FS_Select_f32( aMul2, float32v( 2 ), float32v( ROOT3 ) );
             // b zero value if a mul 2
             b = FS_NMask_f32( b, aMul2 );
@@ -85,7 +85,7 @@ namespace FastNoise
 
             int32v  bit1 = (hash << 31);
             int32v  bit2 = (hash >> 1) << 31;
-            mask32v bit4 = (hash << 29);
+            mask32v bit4 = (mask32v( hash ) << 29);
 
             if constexpr( FS::SIMD_Level > FastSIMD::Level_Scalar && FS::SIMD_Level < FastSIMD::Level_SSE41 )
             {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,7 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}"
 if(MSVC)
     target_compile_options(FastNoise PRIVATE /GS- /fp:fast)
 endif()
+    set_source_files_properties(FastSIMD/FastSIMD_Level_SSE2.cpp PROPERTIES COMPILE_FLAGS "-msse2")
     set_source_files_properties(FastSIMD/FastSIMD_Level_SSE3.cpp PROPERTIES COMPILE_FLAGS "-msse3")
     set_source_files_properties(FastSIMD/FastSIMD_Level_SSSE3.cpp PROPERTIES COMPILE_FLAGS "-mssse3")
     set_source_files_properties(FastSIMD/FastSIMD_Level_SSE41.cpp PROPERTIES COMPILE_FLAGS "-msse4.1")

--- a/src/FastSIMD/Internal/Scalar.h
+++ b/src/FastSIMD/Internal/Scalar.h
@@ -2,6 +2,7 @@
 
 #include "VecTools.h"
 #include <algorithm>
+#include <cmath>
 
 namespace FastSIMD
 {


### PR DESCRIPTION
It seems that 32-bit MinGW-w64 is slightly more stringent in regard to implicit casting. Additionally, SSE2 is not enabled in it by default like in the 64-bit version - rather, for full SSE math support like on x86_64, the flags `-mfpmath=sse -msse2` are needed. (Because the MSVC builds use the flag `/fp:fast`, my understanding was that `-mfpmath=sse` isn't required by FastNoise2 for precision, unless it improves the performance - maybe that should be separately benchmarked, along with `-ffast-math`, perhaps.)

The latter issue might also affect 32-bit GCC builds, but even if it does, that one stayed silent instead of throwing an error like MinGW-w64, so I don't know. :upside_down_face:

Thank You for this awesome library!