### PR TITLE
Add cmake install functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@
 /.vs*
 /out/build
 /build
+/build*
 
 # Allow SDL2 libs
 !/NoiseTool/ThirdParty/SDL2-2.0.12/**

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,24 @@
 # CMakeList.txt : CMake project for FastNoise
 cmake_minimum_required(VERSION 3.7.1)
 
-project(FastNoise2)
+project(FastNoise2 VERSION 0.5.0)
 set(CMAKE_CXX_STANDARD 17)
 
 option(FASTNOISE2_NOISETOOL "Build Noise Tool" ON)
 option(FASTNOISE2_TESTS "Build Test" OFF)
+
+if(MSVC)
+    #setup pdb target location
+    set(pdb_output_dir "${CMAKE_CURRENT_BINARY_DIR}/pdb-files")
+
+    set(CMAKE_PDB_OUTPUT_DIRECTORY "${pdb_output_dir}")
+    set(CMAKE_COMPILE_PDB_OUTPUT_DIRECTORY "${pdb_output_dir}") 
+
+    #need to sync pdp files
+    add_compile_options("/FS")
+endif()
+
+set(install_targets "")
 
 add_subdirectory(src)
 
@@ -15,4 +28,123 @@ endif()
 
 if(FASTNOISE2_TESTS)
 	add_subdirectory(tests)
+endif()
+
+
+#Install -----------------------------------------------------------
+
+# Introduce variables:
+# * CMAKE_INSTALL_LIBDIR
+# * CMAKE_INSTALL_BINDIR
+include(GNUInstallDirs) 
+
+# Layout. This works for all platforms:
+#   * <prefix>/lib*/cmake/<PROJECT-NAME>
+#   * <prefix>/lib*/
+#   * <prefix>/include/
+set(config_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+set(generated_dir "${CMAKE_CURRENT_BINARY_DIR}/generated")
+
+# Configuration
+set(version_config "${generated_dir}/${PROJECT_NAME}ConfigVersion.cmake")
+set(project_config "${generated_dir}/${PROJECT_NAME}Config.cmake")
+set(targets_export_name "${PROJECT_NAME}Targets")
+set(namespace "${PROJECT_NAME}::")
+
+# Include module with fuction 'write_basic_package_version_file'
+include(CMakePackageConfigHelpers)
+
+# Configure '<PROJECT-NAME>ConfigVersion.cmake'
+# Use:
+#   * PROJECT_VERSION
+write_basic_package_version_file(
+    "${version_config}" COMPATIBILITY SameMajorVersion
+)
+
+# Configure '<PROJECT-NAME>Config.cmake'
+# Use variables:
+#   * TARGETS_EXPORT_NAME
+#   * PROJECT_NAME
+configure_package_config_file(
+    "cmake/Config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${config_install_dir}"
+)
+
+# Targets:
+#   * <prefix>/lib/libname.a
+#   * header location after install: <prefix>/include/${PROJECT_NAME}/include.hpp
+#   * headers can be included by C++ code `#include <${PROJECT_NAME}/include.hpp>`
+install(
+    TARGETS ${install_targets}
+    EXPORT "${targets_export_name}"
+    LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
+    RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
+    INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+)
+
+if(FASTNOISE2_NOISETOOL)
+	if(WIN32)
+		#need sdl2 dll on windows, linux its expected to be installed
+		if("${CMAKE_SIZEOF_VOID_P}" STREQUAL "4") #32bit
+			install(
+				FILES NoiseTool/ThirdParty/SDL2-2.0.12/lib/x86/SDL2.dll
+				DESTINATION "${CMAKE_INSTALL_BINDIR}"
+			)
+		else()
+			install(
+				FILES NoiseTool/ThirdParty/SDL2-2.0.12/lib/x64/SDL2.dll
+				DESTINATION "${CMAKE_INSTALL_BINDIR}"
+			)
+		endif()
+	endif()
+endif()
+
+# Headers:
+install(
+    FILES ${install_fastsimd_headers}
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/FastSIMD"
+)
+install(
+    FILES ${install_fastnoise_headers}
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/FastNoise"
+)
+
+# Config
+#   * <prefix>/lib/cmake/${PROJECT_NAME}/${PROJECT_NAME}Config.cmake
+#   * <prefix>/lib/cmake/${PROJECT_NAME}/${PROJECT_NAME}ConfigVersion.cmake
+install(
+    FILES "${project_config}" "${version_config}"
+    DESTINATION "${config_install_dir}"
+)
+
+# Config
+#   * <prefix>/lib/cmake/${PROJECT_NAME}/${PROJECT_NAME}Targets.cmake
+install(
+    EXPORT "${targets_export_name}"
+    NAMESPACE "${namespace}"
+    DESTINATION "${config_install_dir}"
+)
+
+if(MSVC)
+    #install pdbs
+    get_cmake_property(is_multi GENERATOR_IS_MULTI_CONFIG)
+
+    if(is_multi)
+      set(config_suffix "$<CONFIG>")
+    else()
+      set(config_suffix "")
+    endif() 
+
+    if(BUILD_SHARED_LIBS)
+      set(pdb_dst ${CMAKE_INSTALL_BINDIR})
+    else()
+      set(pdb_dst ${CMAKE_INSTALL_LIBDIR})
+    endif() 
+
+    install(
+        DIRECTORY "${pdb_output_dir}/${config_suffix}/"
+        DESTINATION ${pdb_dst}
+    )
 endif()

--- a/NoiseTool/CMakeLists.txt
+++ b/NoiseTool/CMakeLists.txt
@@ -38,6 +38,8 @@ add_executable(NoiseTool
     "NoiseTexture.cpp"
     "ThirdParty/imnodes/imnodes.cpp")
  
+set(install_targets ${install_targets} NoiseTool PARENT_SCOPE)
+
 target_link_libraries(NoiseTool PUBLIC
     FastNoise
     Magnum::Application

--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -1,0 +1,6 @@
+include(CMakeFindDependencyMacro) 
+
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+check_required_components("@PROJECT_NAME@")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -51,8 +51,14 @@ add_library(FastNoise
     ${FastSIMD_internal_headers}
     ${FastSIMD_sources}
 )
+set(install_targets ${install_targets} FastNoise PARENT_SCOPE)
+set(install_fastnoise_headers ${FastNoise_headers} PARENT_SCOPE)
+set(install_fastsimd_headers ${FastSIMD_headers} PARENT_SCOPE)
 
-target_include_directories(FastNoise PUBLIC ../include)
+target_include_directories(FastNoise PUBLIC 
+    $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
 
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     target_compile_options(FastNoise PRIVATE /GL- /GS- /fp:fast)
@@ -86,3 +92,4 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}"
     set_source_files_properties(FastSIMD/FastSIMD_Level_AVX2.cpp PROPERTIES COMPILE_FLAGS "-mavx2 -mfma")
     set_source_files_properties(FastSIMD/FastSIMD_Level_AVX512.cpp PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512dq -mfma")
 endif()
+


### PR DESCRIPTION
Add install support for FastNoise library using cmake. This should fix https://github.com/Auburn/FastNoise2/issues/10