### PR TITLE
resolve cmake import error

### DIFF
--- a/cmake/Config.cmake.in
+++ b/cmake/Config.cmake.in
@@ -2,5 +2,5 @@ include(CMakeFindDependencyMacro)
 
 @PACKAGE_INIT@
 
-include("${CMAKE_CURRENT_LIST_DIR}/@TARGETS_EXPORT_NAME@.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
 check_required_components("@PROJECT_NAME@")


### PR DESCRIPTION
Fixes an incorrectly cased variable that caused cmake to fail when attempting to import FastNoise using `find_package`