### PR TITLE
add missing include

### DIFF
--- a/src/FastNoise/SmartNode.cpp
+++ b/src/FastNoise/SmartNode.cpp
@@ -10,6 +10,7 @@
 #include <list>
 #include <cstring>
 #include <memory>
+#include <algorithm>
 
 namespace FastNoise
 {


### PR DESCRIPTION
User trying to use FastNoise2 ran into ```C:\Users\rgnie\Documents\UnrealProjects\voxel\Source\Dependencies\FastNoise2\src\FastNoise\SmartNode.cpp(43): error C2039: 'min': is not a member of 'std'```

which when adding `#include <algorithm>` fixed it. `algorithm` is the proper header so I am guessing before something else had included min/max somewhere.