### PR TITLE
Add Repeat version of Tileable2D function that accepts custom repeat interval.

### DIFF
--- a/NoiseTool/FastNoiseNodeEditor.cpp
+++ b/NoiseTool/FastNoiseNodeEditor.cpp
@@ -1189,6 +1189,12 @@ FastNoise::OutputMinMax FastNoiseNodeEditor::GenerateNodePreviewNoise( FastNoise
             Node::NoiseSize, Node::NoiseSize,
             mNodeFrequency, mNodeSeed );
 
+    case NoiseTexture::GenType_2DTiledRepeat:
+        return gen->GenTileable2DRepeat(noise, 0, 0,
+            Node::NoiseSize, Node::NoiseSize,
+            Node::NoiseSize, Node::NoiseSize,
+            mNodeFrequency, mNodeSeed);
+
     case NoiseTexture::GenType_3D:
         return gen->GenUniformGrid3D( noise,
             Node::NoiseSize / -2, Node::NoiseSize / -2, 0,

--- a/NoiseTool/NoiseTexture.cpp
+++ b/NoiseTool/NoiseTexture.cpp
@@ -340,6 +340,14 @@ NoiseTexture::TextureData NoiseTexture::BuildTexture( const BuildData& buildData
             buildData.frequency, buildData.seed );
         break;
 
+
+    case GenType_2DTiledRepeat:
+        minMax = gen->GenTileable2DRepeat(noiseData.data(), 0, 0,
+           buildData.size.x(), buildData.size.y(),
+           256, 256,
+           buildData.frequency, buildData.seed );
+        break;
+
     case GenType_3D:
         minMax = gen->GenUniformGrid3D( noiseData.data(),
             (int)buildData.offset.x(), (int)buildData.offset.y(), (int)buildData.offset.z(),

--- a/NoiseTool/NoiseTexture.h
+++ b/NoiseTool/NoiseTexture.h
@@ -24,6 +24,7 @@ namespace Magnum
             GenType_2DTiled,
             GenType_3D,
             GenType_4D,
+            GenType_2DTiledRepeat,
             GenType_Count
         };
 
@@ -31,7 +32,9 @@ namespace Magnum
             "2D\0"
             "2D Tiled\0"
             "3D Slice\0"
-            "4D Slice\0";
+            "4D Slice\0"
+            "2D Tiled Repeat\0";
+
 
         NoiseTexture();
         ~NoiseTexture();

--- a/include/FastNoise/FastNoise_C.h
+++ b/include/FastNoise/FastNoise_C.h
@@ -48,6 +48,13 @@ FASTNOISE_API void fnGenTileable2D( const void* node, float* noiseOut,
                                     int xSize, int ySize,
                                     float frequency, int seed, float* outputMinMax /*nullptr or float[2]*/ );
 
+FASTNOISE_API void fnGenTileable2DRepeat( const void* node, float* noiseOut,
+                                    int xStart, int yStart,
+                                    int xSize, int ySize,
+                                    float xRepeat, float yRepeat,
+                                    float frequency, int seed, float* outputMinMax /*nullptr or float[2]*/ );
+                                    
+
 FASTNOISE_API float fnGenSingle2D( const void* node, float x, float y, int seed );
 FASTNOISE_API float fnGenSingle3D( const void* node, float x, float y, float z, int seed );
 FASTNOISE_API float fnGenSingle4D( const void* node, float x, float y, float z, float w, int seed );

--- a/include/FastNoise/Generators/Generator.h
+++ b/include/FastNoise/Generators/Generator.h
@@ -114,7 +114,13 @@ namespace FastNoise
             float frequency, int seed ) const = 0;
 
         virtual OutputMinMax GenTileable2D( float* out,
-            int xSize, int ySize, float frequency, int seed ) const = 0; 
+            int xSize, int ySize, float frequency, int seed ) const = 0;
+
+        virtual FastNoise::OutputMinMax GenTileable2DRepeat(float* noiseOut,
+           int xStart, int yStart,
+           int xSize, int ySize,
+           float xRepeat, float yRepeat,
+           float frequency, int seed) const = 0;
 
         virtual OutputMinMax GenPositionArray2D( float* out, int count,
             const float* xPosArray, const float* yPosArray,

--- a/include/FastNoise/Generators/Generator.inl
+++ b/include/FastNoise/Generators/Generator.inl
@@ -424,8 +424,8 @@ public:
         size_t index = 0;
 
         float pi2Recip( 0.15915493667f );
-        float xSizePi = repeatX * pi2Recip;
-        float ySizePi = repeatY * pi2Recip;
+        float xSizePi = xRepeat * pi2Recip;
+        float ySizePi = yRepeat * pi2Recip;
         float32v xFreq = float32v( frequency * xSizePi );
         float32v yFreq = float32v( frequency * ySizePi );
         float32v xMul = float32v( 1 / xSizePi );

--- a/src/FastNoise/FastNoise_C.cpp
+++ b/src/FastNoise/FastNoise_C.cpp
@@ -97,7 +97,7 @@ void fnGenTileable2D( const void* node, float* noiseOut, int xSize, int ySize, f
 
 void fnGenTileable2DRepeat( const void* node, float* noiseOut, int xStart, int yStart, int xSize, int ySize, float xRepeat, float yRepeat, float frequency, int seed, float* outputMinMax )
 {
-    StoreMinMax( outputMinMax, ToGen( node )->GenTilable2DRepeat( noiseOut, xStart, yStart, xSize, ySize, xRepeat, yRepeat, frequency, seed ) );
+    StoreMinMax( outputMinMax, ToGen( node )->GenTileable2DRepeat( noiseOut, xStart, yStart, xSize, ySize, xRepeat, yRepeat, frequency, seed ) );
 }
 
 int fnGetMetadataCount()

--- a/src/FastNoise/FastNoise_C.cpp
+++ b/src/FastNoise/FastNoise_C.cpp
@@ -95,6 +95,11 @@ void fnGenTileable2D( const void* node, float* noiseOut, int xSize, int ySize, f
     StoreMinMax( outputMinMax, ToGen( node )->GenTileable2D( noiseOut, xSize, ySize, frequency, seed ) );
 }
 
+void fnGenTileable2DRepeat( const void* node, float* noiseOut, int xStart, int yStart, int xSize, int ySize, float xRepeat, float yRepeat, float frequency, int seed, float* outputMinMax )
+{
+    StoreMinMax( outputMinMax, ToGen( node )->GenTilable2DRepeat( noiseOut, xStart, yStart, xSize, ySize, xRepeat, yRepeat, frequency, seed ) );
+}
+
 int fnGetMetadataCount()
 {
     return (int)FastNoise::Metadata::GetAll().size();


### PR DESCRIPTION
I mostly wanted to use this myself for personal projects, but decided to throw it in a PR.

I've added the function `GenTileable2DRepeat` to the `Generator` class. It serves the same purpose as `GenTileable2D`, but with a few extra parameters.

`xStart`/`yStart`, determining the offset in the same manner as `GenUniformGrid2D`,
and `xRepeat`/`yRepeat`, which determine how long large the Tileable area is.

This allows users to make a large repeating noise period, and sample only parts of it, rather than `GenTileable2D`'s behavior, which only tiles as large as the dataset it's generating for.



I've made sure this compiles and runs at least on Windows, I've added it to the C file, and I've added an option for it in the texture view mode.