### PR TITLE
NEON armv7a & aarch64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,28 @@ cmake_minimum_required(VERSION 3.7.1)
 project(FastNoise2 VERSION 0.9.6)
 set(CMAKE_CXX_STANDARD 17)
 
+
+
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL armv7-a)
+
+set(FASTSIMD_COMPILE_ARMV7 true)
+set(FASTSIMD_COMPILE_ARM true)
+set(FASTSIMD_COMPILE_HAVE_NEON true)
+
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL aarch64)
+
+set(FASTSIMD_COMPILE_AARCH64 true)
+set(FASTSIMD_COMPILE_ARM true)
+set(FASTSIMD_COMPILE_HAVE_NEON true)
+
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL arm)
+
+set(FASTSIMD_COMPILE_ARM true)
+
+endif()
+
+
+
 # determine whether this is a standalone project or included by other projects
 if (NOT DEFINED FASTNOISE2_STANDALONE_PROJECT)
     if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/README.md
+++ b/README.md
@@ -15,11 +15,13 @@ Uses FastSIMD to compile classes with multiple SIMD types and selects the fastes
 - SSE4.1
 - AVX2
 - AVX512
+- NEON
 
 Supports:
 - 32/64 bit
 - Windows
 - Linux
+- Android
 - MacOS
 - MSVC
 - Clang

--- a/include/FastNoise/FastNoise_Config.h
+++ b/include/FastNoise/FastNoise_Config.h
@@ -16,7 +16,8 @@ namespace FastNoise
         FastSIMD::Level_SSE2   |
         FastSIMD::Level_SSE41  |
         FastSIMD::Level_AVX2   |
-        FastSIMD::Level_AVX512 ;
+        FastSIMD::Level_AVX512 |
+        FastSIMD::Level_NEON   ;
     
     class Generator;
     struct Metadata;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,18 +14,40 @@ list(APPEND FastSIMD_headers ${FastSIMD_inline})
 list(APPEND FastSIMD_headers ${FastSIMD_include_inl})
 list(APPEND FastSIMD_internal_headers ${FastSIMD_internal_inl})
 
-set(FastSIMD_sources
-    FastSIMD/FastSIMD.cpp
-    FastSIMD/FastSIMD_Level_AVX2.cpp
-    FastSIMD/FastSIMD_Level_AVX512.cpp
-    FastSIMD/FastSIMD_Level_NEON.cpp
-    FastSIMD/FastSIMD_Level_Scalar.cpp
-    FastSIMD/FastSIMD_Level_SSE2.cpp
-    FastSIMD/FastSIMD_Level_SSE3.cpp
-    FastSIMD/FastSIMD_Level_SSE41.cpp
-    FastSIMD/FastSIMD_Level_SSE42.cpp
-    FastSIMD/FastSIMD_Level_SSSE3.cpp
-)
+
+
+if(FASTSIMD_COMPILE_HAVE_NEON)
+
+    set(FastSIMD_sources
+        FastSIMD/FastSIMD.cpp
+        FastSIMD/FastSIMD_Level_NEON.cpp
+        FastSIMD/FastSIMD_Level_Scalar.cpp
+    )
+
+elseif(FASTSIMD_COMPILE_ARM)
+
+    set(FastSIMD_sources
+        FastSIMD/FastSIMD.cpp
+        FastSIMD/FastSIMD_Level_Scalar.cpp
+    )
+    
+else()
+
+    set(FastSIMD_sources
+        FastSIMD/FastSIMD.cpp
+        FastSIMD/FastSIMD_Level_AVX2.cpp
+        FastSIMD/FastSIMD_Level_AVX512.cpp
+        FastSIMD/FastSIMD_Level_Scalar.cpp
+        FastSIMD/FastSIMD_Level_SSE2.cpp
+        FastSIMD/FastSIMD_Level_SSE3.cpp
+        FastSIMD/FastSIMD_Level_SSE41.cpp
+        FastSIMD/FastSIMD_Level_SSE42.cpp
+        FastSIMD/FastSIMD_Level_SSSE3.cpp
+    )
+
+endif()
+
+
 
 file(GLOB FastNoise_headers "../include/FastNoise/*.h")
 file(GLOB FastNoise_inl "../include/FastNoise/*.inl")
@@ -79,16 +101,22 @@ set_target_properties(FastNoise PROPERTIES
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     target_compile_options(FastNoise PRIVATE /GL- /GS- /fp:fast /wd4251)
     
-    if(CMAKE_SIZEOF_VOID_P EQUAL 4)
-        set_source_files_properties(FastSIMD/FastSIMD_Level_Scalar.cpp PROPERTIES COMPILE_FLAGS "/arch:SSE")
-        set_source_files_properties(FastSIMD/FastSIMD_Level_SSE2.cpp PROPERTIES COMPILE_FLAGS "/arch:SSE2")
-        set_source_files_properties(FastSIMD/FastSIMD_Level_SSE3.cpp PROPERTIES COMPILE_FLAGS "/arch:SSE2")
-        set_source_files_properties(FastSIMD/FastSIMD_Level_SSSE3.cpp PROPERTIES COMPILE_FLAGS "/arch:SSE2")
-        set_source_files_properties(FastSIMD/FastSIMD_Level_SSE41.cpp PROPERTIES COMPILE_FLAGS "/arch:SSE2")
-        set_source_files_properties(FastSIMD/FastSIMD_Level_SSE42.cpp PROPERTIES COMPILE_FLAGS "/arch:SSE2")
+    if(NOT FASTSIMD_COMPILE_ARM)
+    
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4)
+            set_source_files_properties(FastSIMD/FastSIMD_Level_Scalar.cpp PROPERTIES COMPILE_FLAGS "/arch:SSE")
+            set_source_files_properties(FastSIMD/FastSIMD_Level_SSE2.cpp PROPERTIES COMPILE_FLAGS "/arch:SSE2")
+            set_source_files_properties(FastSIMD/FastSIMD_Level_SSE3.cpp PROPERTIES COMPILE_FLAGS "/arch:SSE2")
+            set_source_files_properties(FastSIMD/FastSIMD_Level_SSSE3.cpp PROPERTIES COMPILE_FLAGS "/arch:SSE2")
+            set_source_files_properties(FastSIMD/FastSIMD_Level_SSE41.cpp PROPERTIES COMPILE_FLAGS "/arch:SSE2")
+            set_source_files_properties(FastSIMD/FastSIMD_Level_SSE42.cpp PROPERTIES COMPILE_FLAGS "/arch:SSE2")
+        endif()
+        set_source_files_properties(FastSIMD/FastSIMD_Level_AVX2.cpp PROPERTIES COMPILE_FLAGS "/arch:AVX2")
+        set_source_files_properties(FastSIMD/FastSIMD_Level_AVX512.cpp PROPERTIES COMPILE_FLAGS "/arch:AVX512")
+    
+    elseif(FASTSIMD_COMPILE_ARMV7)
+        set_source_files_properties(FastSIMD/FastSIMD_Level_NEON.cpp PROPERTIES COMPILE_FLAGS "/arch:NEON")
     endif()
-    set_source_files_properties(FastSIMD/FastSIMD_Level_AVX2.cpp PROPERTIES COMPILE_FLAGS "/arch:AVX2")
-    set_source_files_properties(FastSIMD/FastSIMD_Level_AVX512.cpp PROPERTIES COMPILE_FLAGS "/arch:AVX512")
 
 elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
     if(MSVC)
@@ -96,16 +124,24 @@ elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}"
     else()
         target_compile_options(FastNoise PRIVATE -ffast-math -fno-stack-protector)        
     endif()
+    
+    if(NOT FASTSIMD_COMPILE_ARM)
 
-    if(CMAKE_SIZEOF_VOID_P EQUAL 4 OR "${CMAKE_CXX_FLAGS}" MATCHES "-m32")
-        set_source_files_properties(FastSIMD/FastSIMD_Level_Scalar.cpp PROPERTIES COMPILE_FLAGS "-msse")
-        set_source_files_properties(FastSIMD/FastSIMD_Level_SSE2.cpp PROPERTIES COMPILE_FLAGS "-msse2")
+        if(CMAKE_SIZEOF_VOID_P EQUAL 4 OR "${CMAKE_CXX_FLAGS}" MATCHES "-m32")
+            set_source_files_properties(FastSIMD/FastSIMD_Level_Scalar.cpp PROPERTIES COMPILE_FLAGS "-msse")
+            set_source_files_properties(FastSIMD/FastSIMD_Level_SSE2.cpp PROPERTIES COMPILE_FLAGS "-msse2")
+        endif()
+        set_source_files_properties(FastSIMD/FastSIMD_Level_SSE3.cpp PROPERTIES COMPILE_FLAGS "-msse3")
+        set_source_files_properties(FastSIMD/FastSIMD_Level_SSSE3.cpp PROPERTIES COMPILE_FLAGS "-mssse3")
+        set_source_files_properties(FastSIMD/FastSIMD_Level_SSE41.cpp PROPERTIES COMPILE_FLAGS "-msse4.1")
+        set_source_files_properties(FastSIMD/FastSIMD_Level_SSE42.cpp PROPERTIES COMPILE_FLAGS "-msse4.2")
+        set_source_files_properties(FastSIMD/FastSIMD_Level_AVX2.cpp PROPERTIES COMPILE_FLAGS "-mavx2 -mfma")
+        set_source_files_properties(FastSIMD/FastSIMD_Level_AVX512.cpp PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512dq -mfma")
+    
+    elseif(FASTSIMD_COMPILE_ARMV7)
+        set_source_files_properties(FastSIMD/FastSIMD_Level_NEON.cpp PROPERTIES COMPILE_FLAGS "-march=armv7-a -mfpu=neon")
     endif()
-    set_source_files_properties(FastSIMD/FastSIMD_Level_SSE3.cpp PROPERTIES COMPILE_FLAGS "-msse3")
-    set_source_files_properties(FastSIMD/FastSIMD_Level_SSSE3.cpp PROPERTIES COMPILE_FLAGS "-mssse3")
-    set_source_files_properties(FastSIMD/FastSIMD_Level_SSE41.cpp PROPERTIES COMPILE_FLAGS "-msse4.1")
-    set_source_files_properties(FastSIMD/FastSIMD_Level_SSE42.cpp PROPERTIES COMPILE_FLAGS "-msse4.2")
-    set_source_files_properties(FastSIMD/FastSIMD_Level_AVX2.cpp PROPERTIES COMPILE_FLAGS "-mavx2 -mfma")
-    set_source_files_properties(FastSIMD/FastSIMD_Level_AVX512.cpp PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512dq -mfma")
+    
+    
 endif()
 

--- a/src/FastSIMD/FastSIMD.cpp
+++ b/src/FastSIMD/FastSIMD.cpp
@@ -3,11 +3,16 @@
 #include <algorithm>
 #include <cstdint>
 
+#if FASTSIMD_x86
+
 #ifdef __GNUG__
 #include <x86intrin.h>
 #else
 #include <intrin.h>
 #endif
+
+#endif
+
 
 #include "FastSIMD/SIMDTypeList.h"
 

--- a/src/FastSIMD/Internal/NEON.h
+++ b/src/FastSIMD/Internal/NEON.h
@@ -1,424 +1,552 @@
 #pragma once
 
+
 #include <arm_neon.h>
+#include <assert.h>
 
 #include "VecTools.h"
 
-struct NEON_f32x4
+#if defined(__arm__) || !defined(__aarch64__)
+#define FASTSIMD_USE_ARMV7
+#endif
+
+
+namespace FastSIMD
 {
-    FASTSIMD_INTERNAL_TYPE_SET( NEON_f32x4, float32x4_t );
 
-    constexpr FS_INLINE static uint8_t Size()
+    struct NEON_f32x4
     {
-        return 4;
-    }
+        FASTSIMD_INTERNAL_TYPE_SET( NEON_f32x4, float32x4_t );
 
-    FS_INLINE static NEON_f32x4 Zero()
+
+        FS_INLINE static NEON_f32x4 Zero()
+        {
+            return vdupq_n_f32( 0 );
+        }
+
+        FS_INLINE static NEON_f32x4 Incremented()
+        {
+            alignas(16) const float f[4]{ 0.0f, 1.0f, 2.0f, 3.0f };
+            return vld1q_f32( f );
+        }
+
+        FS_INLINE explicit NEON_f32x4( float f )
+        {
+            *this = vdupq_n_f32( f );
+        }
+
+        FS_INLINE explicit NEON_f32x4( float f0, float f1, float f2, float f3 )
+        {
+            alignas(16) const float f[4]{ f0, f1, f2, f3 };
+            *this = vld1q_f32( f );
+        }
+
+        FS_INLINE NEON_f32x4& operator+=( const NEON_f32x4& rhs )
+        {
+            *this = vaddq_f32( *this, rhs );
+            return *this;
+        }
+
+        FS_INLINE NEON_f32x4& operator-=( const NEON_f32x4& rhs )
+        {
+            *this = vsubq_f32( *this, rhs );
+            return *this;
+        }
+
+        FS_INLINE NEON_f32x4& operator*=( const NEON_f32x4& rhs )
+        {
+            *this = vmulq_f32( *this, rhs );
+            return *this;
+        }
+        
+        #ifdef FASTSIMD_USE_ARMV7
+            FS_INLINE NEON_f32x4& operator/=( const NEON_f32x4& rhs )
+            {
+                
+                float32x4_t reciprocal = vrecpeq_f32( rhs );
+                // use a couple Newton-Raphson steps to refine the estimate.  Depending on your
+                // application's accuracy requirements, you may be able to get away with only
+                // one refinement (instead of the two used here).  Be sure to test!
+                reciprocal = vmulq_f32( vrecpsq_f32( rhs, reciprocal ), reciprocal );
+                reciprocal = vmulq_f32( vrecpsq_f32( rhs, reciprocal ), reciprocal );
+
+                // and finally, compute a/b = a*(1/b)
+                *this = vmulq_f32( *this, reciprocal );
+                
+                return *this;
+            }
+        #else
+            FS_INLINE NEON_f32x4& operator/=( const NEON_f32x4& rhs )
+            {
+                /*
+                float32x4_t reciprocal = vrecpeq_f32( rhs );
+                reciprocal = vmulq_f32( vrecpsq_f32( rhs, reciprocal ), reciprocal );
+                reciprocal = vmulq_f32( vrecpsq_f32( rhs, reciprocal ), reciprocal );
+                *this = vmulq_f32( *this, reciprocal );
+                */
+                *this = vdivq_f32( *this, rhs );
+                
+                return *this;
+            }
+        #endif
+
+        
+        
+        
+        FS_INLINE NEON_f32x4& operator&=( const NEON_f32x4& rhs )
+        {
+            *this = vreinterpretq_f32_s32( vandq_s32( vreinterpretq_s32_f32( *this ), vreinterpretq_s32_f32( rhs ) ) );
+            return *this;
+        }
+        FS_INLINE NEON_f32x4& operator|=( const NEON_f32x4& rhs )
+        {
+            *this = vreinterpretq_f32_s32( vorrq_s32( vreinterpretq_s32_f32( *this ), vreinterpretq_s32_f32( rhs ) ) );
+            return *this;
+        }
+        FS_INLINE NEON_f32x4& operator^=( const NEON_f32x4& rhs )
+        {
+            *this = vreinterpretq_f32_s32( veorq_s32( vreinterpretq_s32_f32( *this ), vreinterpretq_s32_f32( rhs ) ) );
+            return *this;
+        }
+
+        FS_INLINE NEON_f32x4 operator-() const
+        {
+            return vnegq_f32( *this );
+        }
+        FS_INLINE NEON_f32x4 operator~() const
+        {
+            return vreinterpretq_f32_u32( vmvnq_u32( vreinterpretq_u32_f32(*this) ) );
+        }
+
+    };
+
+    FASTSIMD_INTERNAL_OPERATORS_FLOAT( NEON_f32x4 )
+
+
+    struct NEON_i32x4
     {
-        return vdupq_n_f32( 0 );
-    }
+        FASTSIMD_INTERNAL_TYPE_SET( NEON_i32x4, int32x4_t );
+        
 
-    FS_INLINE static NEON_f32x4 Incremented()
-    {
-        alignas(16) const float f[4]{ 0.0f, 1.0f, 2.0f, 3.0f };
-        return vld1q_f32( f );
-    }
+        FS_INLINE static NEON_i32x4 Zero()
+        {
+            return vdupq_n_s32( 0 );
+        }
 
-    FS_INLINE explicit NEON_f32x4( float f )
-    {
-        *this = vdupq_n_f32( f );
-    }
+        FS_INLINE static NEON_i32x4 Incremented()
+        {
+            alignas(16) const int32_t f[4]{ 0, 1, 2, 3 };
+            return vld1q_s32( f );
+        }
 
-    FS_INLINE explicit NEON_f32x4( float f0, float f1, float f2, float f3 )
-    {
-        alignas(16) const float f[4]{ f0, f1, f2, f3 };
-        *this = vld1q_f32( f );
-    }
+        FS_INLINE explicit NEON_i32x4( int32_t i )
+        {
+            *this = vdupq_n_s32( i );
+        }
 
-    FS_INLINE NEON_f32x4& operator+=( const NEON_f32x4& rhs )
-    {
-        *this = vaddq_f32( *this, rhs );
-        return *this;
-    }
+        FS_INLINE explicit NEON_i32x4( int32_t i0, int32_t i1, int32_t i2, int32_t i3 )
+        {
+            alignas(16) const int32_t f[4]{ i0, i1, i2, i3 };
+            *this = vld1q_s32( f );
+        }
 
-    FS_INLINE NEON_f32x4& operator-=( const NEON_f32x4& rhs )
-    {
-        *this = vsubq_f32( *this, rhs );
-        return *this;
-    }
+        FS_INLINE NEON_i32x4& operator+=( const NEON_i32x4& rhs )
+        {
+            *this = vaddq_s32( *this, rhs );
+            return *this;
+        }
 
-    FS_INLINE NEON_f32x4& operator*=( const NEON_f32x4& rhs )
-    {
-        *this = vmulq_f32( *this, rhs );
-        return *this;
-    }
+        FS_INLINE NEON_i32x4& operator-=( const NEON_i32x4& rhs )
+        {
+            *this = vsubq_s32( *this, rhs );
+            return *this;
+        }
 
-    FS_INLINE NEON_f32x4& operator/=( const NEON_f32x4& rhs )
-    {
-        float32x4_t reciprocal = vrecpeq_f32( rhs );
-        // use a couple Newton-Raphson steps to refine the estimate.  Depending on your
-        // application's accuracy requirements, you may be able to get away with only
-        // one refinement (instead of the two used here).  Be sure to test!
-        reciprocal = vmulq_f32( vrecpsq_f32( rhs, reciprocal ), reciprocal );
-        reciprocal = vmulq_f32( vrecpsq_f32( rhs, reciprocal ), reciprocal );
+        FS_INLINE NEON_i32x4& operator*=( const NEON_i32x4& rhs )
+        {
+            *this = vmulq_s32( *this, rhs );
+            return *this;
+        }
 
-        // and finally, compute a/b = a*(1/b)
-        *this = vmulq_f32( *this, reciprocal );
-        return *this;
-    }
+        FS_INLINE NEON_i32x4& operator&=( const NEON_i32x4& rhs )
+        {
+            *this = vandq_s32( *this, rhs );
+            return *this;
+        }
 
-    FS_INLINE NEON_f32x4 operator-() const
-    {
-        return vnegq_f32( *this );
-    }
-};
+        FS_INLINE NEON_i32x4& operator|=( const NEON_i32x4& rhs )
+        {
+            *this = vorrq_s32( *this, rhs );
+            return *this;
+        }
 
-FASTSIMD_INTERNAL_OPERATORS_FLOAT( NEON_f32x4 )
+        FS_INLINE NEON_i32x4& operator^=( const NEON_i32x4& rhs )
+        {
+            *this = veorq_s32( *this, rhs );
+            return *this;
+        }
 
+        FS_INLINE NEON_i32x4& operator>>=( const int32_t rhs )
+        {
+            int32x4_t rhs2 = vdupq_n_s32( -rhs );
+            *this = vshlq_s32(*this, rhs2);//use shift right by constant for faster execution
+            return *this;
+        }
 
-struct NEON_i32x4
-{
-    FASTSIMD_INTERNAL_TYPE_SET( NEON_i32x4, int32x4_t );
+        FS_INLINE NEON_i32x4& operator<<=( const int32_t rhs )
+        {
+            int32x4_t rhs2 = vdupq_n_s32( rhs );
+            *this = vshlq_s32(*this, rhs2);//use shift left by constant for faster execution
+            return *this;
+        }
 
-    constexpr FS_INLINE static uint8_t Size()
-    {
-        return 4;
-    }
+        FS_INLINE NEON_i32x4 operator~() const
+        {
+            return vmvnq_s32( *this );
+        }
 
-    FS_INLINE static NEON_i32x4 Zero()
-    {
-        return vdupq_n_s32( 0 );
-    }
+        FS_INLINE NEON_i32x4 operator-() const
+        {
+            return vnegq_s32( *this );
+        }
+    };
 
-    FS_INLINE static NEON_i32x4 Incremented()
-    {
-        alignas(16) const int32_t f[4]{ 0, 1, 2, 3 };
-        return vld1q_s32( f );
-    }
-
-    FS_INLINE explicit NEON_i32x4( int32_t i )
-    {
-        *this = vdupq_n_s32( i );
-    }
-
-    FS_INLINE explicit NEON_i32x4( int32_t i0, int32_t i1, int32_t i2, int32_t i3 )
-    {
-        alignas(16) const int32_t f[4]{ i0, i1, i2, i3 };
-        *this = vld1q_s32( f );
-    }
-
-    FS_INLINE NEON_i32x4& operator+=( const NEON_i32x4& rhs )
-    {
-        *this = vaddq_s32( *this, rhs );
-        return *this;
-    }
-
-    FS_INLINE NEON_i32x4& operator-=( const NEON_i32x4& rhs )
-    {
-        *this = vsubq_s32( *this, rhs );
-        return *this;
-    }
-
-    FS_INLINE NEON_i32x4& operator*=( const NEON_i32x4& rhs )
-    {
-        *this = vmulq_s32( *this, rhs );
-        return *this;
-    }
-
-    FS_INLINE NEON_i32x4& operator&=( const NEON_i32x4& rhs )
-    {
-        *this = vandq_s32( *this, rhs );
-        return *this;
-    }
-
-    FS_INLINE NEON_i32x4& operator|=( const NEON_i32x4& rhs )
-    {
-        *this = vorrq_s32( *this, rhs );
-        return *this;
-    }
-
-    FS_INLINE NEON_i32x4& operator^=( const NEON_i32x4& rhs )
-    {
-        *this = veorq_s32( *this, rhs );
-        return *this;
-    }
-
-    FS_INLINE NEON_i32x4& operator>>=( const int32_t rhs )
-    {
-        *this = vshrq_n_s32( *this, rhs );
-        return *this;
-    }
-
-    FS_INLINE NEON_i32x4& operator<<=( const int32_t rhs )
-    {
-        *this = vshlq_n_s32( *this, rhs );
-        return *this;
-    }
-
-    FS_INLINE NEON_i32x4 operator~() const
-    {
-        return vmvnq_s32( *this );
-    }
-
-    FS_INLINE NEON_i32x4 operator-() const
-    {
-        return vnegq_s32( *this );
-    }
-};
-
-FASTSIMD_INTERNAL_OPERATORS_INT( NEON_i32x4, int32_t )
-
-template<FastSIMD::eLevel LEVEL_T>
-class FastSIMD_NEON_T
-{
-public:
-    static const FastSIMD::eLevel SIMD_Level = LEVEL_T;
-    static const size_t VectorSize = 128 / 8;
-
-    typedef NEON_f32x4 float32v;
-    typedef NEON_i32x4 int32v;
-    typedef NEON_i32x4 mask32v;
-
-    // Load
-
-    FS_INLINE static float32v Load_f32( void const* p )
-    {
-        return vld1q_f32( reinterpret_cast<float const*>(p) );
-    }
-
-    FS_INLINE static int32v Load_i32( void const* p )
-    {
-        return vld1q_s32( reinterpret_cast<int32_t const*>(p) );
-    }
-
-    // Store
-
-    FS_INLINE static void Store_f32( void* p, float32v a )
-    {
-        vst1q_f32( reinterpret_cast<float*>(p), a );
-    }
-
-    FS_INLINE static void Store_i32( void* p, int32v a )
-    {
-        vst1q_s32( reinterpret_cast<int32_t*>(p), a );
-    }
-
-    // Cast
-
-    FS_INLINE static float32v Casti32_f32( int32v a )
-    {
-        return vreinterpretq_f32_s32( a );
-    }
-
-    FS_INLINE static int32v Castf32_i32( float32v a )
-    {
-        return vreinterpretq_s32_f32( a );
-    }
-
-    // Convert
-
-    FS_INLINE static float32v Converti32_f32( int32v a )
-    {
-        return vcvtq_f32_s32( a );
-    }
-
-    FS_INLINE static int32v Convertf32_i32( float32v a )
-    {
-        return vcvtq_s32_f32( a );
-    }
-
-    // Comparisons
-
-    FS_INLINE static mask32v Equal_f32( float32v a, float32v b )
-    {
-        return vreinterpretq_s32_u32( vceq_f32( a, b ) );
-    }
-
-    FS_INLINE static mask32v GreaterThan_f32( float32v a, float32v b )
-    {
-        return vreinterpretq_s32_u32( vcgtq_f32( a, b ) );
-    }
-
-    FS_INLINE static mask32v LessThan_f32( float32v a, float32v b )
-    {
-        return vreinterpretq_s32_u32( vcltq_f32( a, b ) );
-    }
-
-    FS_INLINE static mask32v GreaterEqualThan_f32( float32v a, float32v b )
-    {
-        return vreinterpretq_s32_u32( vcgeq_f32( a, b ) );
-    }
-
-    FS_INLINE static mask32v LessEqualThan_f32( float32v a, float32v b )
-    {
-        return vreinterpretq_s32_u32( vcleq_f32( a, b ) );
-    }
-
-    FS_INLINE static mask32v Equal_i32( int32v a, int32v b )
-    {
-        return vceq_s32( a, b );
-    }
-
-    FS_INLINE static mask32v GreaterThan_i32( int32v a, int32v b )
-    {
-        return vcgtq_s32( a, b );
-    }
-
-    FS_INLINE static mask32v LessThan_i32( int32v a, int32v b )
-    {
-        return vcltq_s32( a, b );
-    }
-
-    // Select
-
-    FS_INLINE static float32v Select_f32( mask32v m, float32v a, float32v b )
-    {
-        return vbslq_f32( vreinterpretq_u32_s32( mask ), b, a );
-    }
-
-    FS_INLINE static int32v Select_i32( mask32v m, int32v a, int32v b )
-    {
-        return vbslq_s32( vreinterpretq_u32_s32( mask ), b, a );
-    }
-
-    // Min, Max
-
-    FS_INLINE static float32v Min_f32( float32v a, float32v b )
-    {
-        return vminq_f32( a, b );
-    }
-
-    FS_INLINE static float32v Max_f32( float32v a, float32v b )
-    {
-        return vmaxq_f32( a, b );
-    }
-
-    FS_INLINE static int32v Min_i32( int32v a, int32v b )
-    {
-        return vminq_s32( a, b );
-    }
-
-    FS_INLINE static int32v Max_i32( int32v a, int32v b )
-    {
-        return vmaxq_s32( a, b );
-    }
+    FASTSIMD_INTERNAL_OPERATORS_INT( NEON_i32x4, int32_t )
     
-    // Bitwise
 
-    FS_INLINE static float32v BitwiseAnd_f32( float32v a, float32v b )
+    template<eLevel LEVEL_T>
+    class NEON_T
     {
-        return vreinterpretq_f32_s32( vandq_s32( vreinterpretq_s32_f32( a ), vreinterpretq_s32_f32( b ) ) );
-    }
+    public:
+        static constexpr eLevel SIMD_Level = FastSIMD::Level_NEON;
 
-    FS_INLINE static float32v BitwiseOr_f32( float32v a, float32v b )
-    {
-        return vreinterpretq_f32_s32( vorrq_s32( vreinterpretq_s32_f32( a ), vreinterpretq_s32_f32( b ) ) );
-    }
+        
+        template<size_t ElementSize>
+        static constexpr size_t VectorSize = (128 / 8) / ElementSize;
 
-    FS_INLINE static float32v BitwiseXor_f32( float32v a, float32v b )
-    {
-        return vreinterpretq_f32_s32( veorq_s32( vreinterpretq_s32_f32( a ), vreinterpretq_s32_f32( b ) ) );
-    }
+        typedef NEON_f32x4 float32v;
+        typedef NEON_i32x4   int32v;
+        typedef NEON_i32x4  mask32v;
 
-    FS_INLINE static float32v BitwiseNot_f32( float32v a )
-    {
-        return vreinterpretq_f32_s32( vmvn_s32( vreinterpretq_s32_f32( a ), vreinterpretq_s32_f32( b ) ) );
-    }
+        FS_INLINE static float32v Load_f32( void const* p )
+        {
+            return vld1q_f32( reinterpret_cast<float const*>(p) );
+        }
 
-    FS_INLINE static float32v BitwiseAndNot_f32( float32v a, float32v b )
-    {
-        return vreinterpretq_f32_s32( vandq_s32( vreinterpretq_s32_f32( a ), vmvn_s32( vreinterpretq_s32_f32( b ) ) ) );
-    }
+        FS_INLINE static int32v Load_i32( void const* p )
+        {
+            return vld1q_s32( reinterpret_cast<int32_t const*>(p) );
+        }
 
-    FS_INLINE static int32v BitwiseAndNot_i32( int32v a, int32v b )
-    {
-        return vandq_s32( a , vmvn_s32( b ) );
-    }
+        // Store
 
-    // Abs
+        FS_INLINE static void Store_f32( void* p, float32v a )
+        {
+            vst1q_f32( reinterpret_cast<float*>(p), a );
+        }
 
-    FS_INLINE static float32v Abs_f32( float32v a )
-    {
-        return vabsq_f32( a );
-    }
+        FS_INLINE static void Store_i32( void* p, int32v a )
+        {
+            vst1q_s32( reinterpret_cast<int32_t*>(p), a );
+        }
 
-    FS_INLINE static int32v Abs_i32( int32v a )
-    {
-        return vabsq_s32( a );
-    }
+        // Cast
 
-    // Float math
+        FS_INLINE static float32v Casti32_f32( int32v a )
+        {
+            return vreinterpretq_f32_s32( a );
+        }
 
-    FS_INLINE static float32v Sqrt_f32( float32v a )
-    {
-        return vsqrtq_f32( a );
-    }
+        FS_INLINE static int32v Castf32_i32( float32v a )
+        {
+            return vreinterpretq_s32_f32( a );
+        }
 
-    FS_INLINE static float32v InvSqrt_f32( float32v a )
-    {
-        return vrsqrteq_f32( a );
-    }
+        // Convert
 
-    // Floor, Ceil, Round: http://dss.stephanierct.com/DevBlog/?p=8
+        FS_INLINE static float32v Converti32_f32( int32v a )
+        {
+            return vcvtq_f32_s32( a );
+        }
 
-    FS_INLINE static float32v Floor_f32( float32v a )
-    {
-#if FASTSIMD_CONFIG_GENERATE_CONSTANTS
-        const float32x4_t f1 = vdupq_n_f32( 1.0f ); //_mm_castsi128_ps( _mm_slli_epi32( _mm_srli_epi32( _mm_cmpeq_epi32( _mm_setzero_si128(), _mm_setzero_si128() ), 25 ), 23 ) );
-#else
-        const float32x4_t f1 = vdupq_n_f32( 1.0f );
-#endif
-        float32x4_t fval = vrndmq_f32( a );
+        FS_INLINE static int32v Convertf32_i32( float32v a )
+        {
+            return vcvtq_s32_f32( a );
+        }
 
-        return vsubq_f32( fval, BitwiseAnd_f32( vcltq_f32( a, fval ), f1 ) );
-    }
+        // Comparisons
 
-    FS_INLINE static float32v Ceil_f32( float32v a )
-    {
-#if FASTSIMD_CONFIG_GENERATE_CONSTANTS
-        const __m128 f1 = vdupq_n_f32( 1.0f ); //_mm_castsi128_ps( _mm_slli_epi32( _mm_srli_epi32( _mm_cmpeq_epi32( _mm_setzero_si128(), _mm_setzero_si128() ), 25 ), 23 ) );
-#else
-        const __m128 f1 = vdupq_n_f32( 1.0f );
-#endif
-        float32x4_t fval = vrndmq_f32( a );
+        FS_INLINE static mask32v Equal_f32( float32v a, float32v b )
+        {
+            return vreinterpretq_s32_u32( vceqq_f32( a, b ) );
+        }
 
-        return vaddq_f32( fval, BitwiseAnd_f32( vcltq_f32( a, fval ), f1 ) );
-    }
+        FS_INLINE static mask32v GreaterThan_f32( float32v a, float32v b )
+        {
+            return vreinterpretq_s32_u32( vcgtq_f32( a, b ) );
+        }
 
-    template<FastSIMD::eLevel L = LEVEL_T>
-    FS_INLINE static FS_ENABLE_IF( L < FastSIMD::ELevel_SSE41, float32v ) Round_f32( float32v a )
-    {
-#if FASTSIMD_CONFIG_GENERATE_CONSTANTS
-        const __m128 nearest2 = _mm_castsi128_ps( _mm_srli_epi32( _mm_cmpeq_epi32( _mm_setzero_si128(), _mm_setzero_si128() ), 2 ) );
-#else
-        const __m128 nearest2 = vdupq_n_f32( 1.99999988079071044921875f );
-#endif
-        __m128 aTrunc = _mm_cvtepi32_ps( _mm_cvttps_epi32( a ) );       // truncate a
-        __m128 rmd = _mm_sub_ps( a, aTrunc );                           // get remainder
-        __m128 rmd2 = _mm_mul_ps( rmd, nearest2 );                      // mul remainder by near 2 will yield the needed offset
-        __m128 rmd2Trunc = _mm_cvtepi32_ps( _mm_cvttps_epi32( rmd2 ) ); // after being truncated of course
-        return _mm_add_ps( aTrunc, rmd2Trunc );
-    }
+        FS_INLINE static mask32v LessThan_f32( float32v a, float32v b )
+        {
+            return vreinterpretq_s32_u32( vcltq_f32( a, b ) );
+        }
 
-    template<FastSIMD::eLevel L = LEVEL_T>
-    FS_INLINE static FS_ENABLE_IF( L >= FastSIMD::ELevel_SSE41, float32v ) Round_f32( float32v a )
-    {
-        return vrndnq_f32( a );
-    }
+        FS_INLINE static mask32v GreaterEqualThan_f32( float32v a, float32v b )
+        {
+            return vreinterpretq_s32_u32( vcgeq_f32( a, b ) );
+        }
 
-    // Mask
+        FS_INLINE static mask32v LessEqualThan_f32( float32v a, float32v b )
+        {
+            return vreinterpretq_s32_u32( vcleq_f32( a, b ) );
+        }
 
-    FS_INLINE static int32v Mask_i32( int32v a, mask32v m )
-    {
-        return a & m;
-    }
+        FS_INLINE static mask32v Equal_i32( int32v a, int32v b )
+        {
+            return vceqq_s32( a, b );
+        }
 
-    FS_INLINE static float32v Mask_f32( float32v a, mask32v m )
-    {
-        return BitwiseAnd_f32( a, vreinterpretq_f32_s32( m ) );
-    }
-};
+        FS_INLINE static mask32v GreaterThan_i32( int32v a, int32v b )
+        {
+            return vcgtq_s32( a, b );
+        }
 
+        FS_INLINE static mask32v LessThan_i32( int32v a, int32v b )
+        {
+            return vcltq_s32( a, b );
+        }
+
+        // Select
+
+        FS_INLINE static float32v Select_f32( mask32v m, float32v a, float32v b )
+        {
+            return vbslq_f32( vreinterpretq_u32_s32( m ), a, b );
+        }
+        FS_INLINE static int32v Select_i32( mask32v m, int32v a, int32v b )
+        {
+            return vbslq_s32( vreinterpretq_u32_s32( m ), a, b );
+        }
+
+        // Min, Max
+
+        FS_INLINE static float32v Min_f32( float32v a, float32v b )
+        {
+            return vminq_f32( a, b );
+        }
+
+        FS_INLINE static float32v Max_f32( float32v a, float32v b )
+        {
+            return vmaxq_f32( a, b );
+        }
+
+        FS_INLINE static int32v Min_i32( int32v a, int32v b )
+        {
+            return vminq_s32( a, b );
+        }
+
+        FS_INLINE static int32v Max_i32( int32v a, int32v b )
+        {
+            return vmaxq_s32( a, b );
+        }
+        
+        // Bitwise
+
+        FS_INLINE static float32v BitwiseAnd_f32( float32v a, float32v b )
+        {
+            return vreinterpretq_f32_u32( vandq_u32( vreinterpretq_u32_f32( a ), vreinterpretq_u32_f32( b ) ) );
+        }
+/*
+        FS_INLINE static float32v BitwiseOr_f32( float32v a, float32v b )
+        {
+            return vreinterpretq_f32_u32( vorrq_u32( vreinterpretq_u32_f32( a ), vreinterpretq_u32_f32( b ) ) );
+        }
+
+        FS_INLINE static float32v BitwiseXor_f32( float32v a, float32v b )
+        {
+            return vreinterpretq_f32_u32( veorq_u32( vreinterpretq_u32_f32( a ), vreinterpretq_u32_f32( b ) ) );
+        }
+
+        FS_INLINE static float32v BitwiseNot_f32( float32v a )
+        {
+            return vreinterpretq_f32_u32( vmvnq_u32( vreinterpretq_u32_f32( a ) ) );
+        }
+*/
+        FS_INLINE static float32v BitwiseAndNot_f32( float32v a, float32v b )
+        {
+            return vreinterpretq_f32_u32( vandq_u32( vreinterpretq_u32_f32( a ), vmvnq_u32( vreinterpretq_u32_f32( b ) ) ) );
+        }
+
+        FS_INLINE static int32v BitwiseAndNot_i32( int32v a, int32v b )
+        {
+            return vandq_s32( a , vmvnq_s32( b ) );
+        }
+
+        // Abs
+
+        FS_INLINE static float32v Abs_f32( float32v a )
+        {
+            return vabsq_f32( a );
+        }
+
+        FS_INLINE static int32v Abs_i32( int32v a )
+        {
+            return vabsq_s32( a );
+        }
+
+
+
+        
+
+        FS_INLINE static float32v InvSqrt_f32( float32v a )
+        {
+            return vrsqrteq_f32( a );
+        }
+        
+        
+        // Floor, Ceil, Round: http://dss.stephanierct.com/DevBlog/?p=8
+
+        
+        #ifdef FASTSIMD_USE_ARMV7
+        
+            FS_INLINE static float32v IntFloor_f32(float32v a)
+            {
+                static const float32x4_t cmpval = vcvtq_f32_s32( vdupq_n_s32( 0x7FFFFFFF ) );
+                
+
+                float32x4_t cmp1 = vcagtq_f32( a, cmpval );
+                float32x4_t cmp2 = vcaleq_f32( a, cmpval );
+
+                float32x4_t tr = vcvtq_f32_s32( vcvtq_s32_f32( a ) );
+
+                uint32x4_t xcmp1 = vandq_u32(cmp1, vreinterpretq_u32_f32( a ) );
+                uint32x4_t xcmp2 = vandq_u32(cmp2, vreinterpretq_u32_f32( tr ) );
+
+                uint32x4_t res0 = vorrq_u32( xcmp1, xcmp2 );
+
+                float32x4_t res1 = vreinterpretq_f32_u32( res0 );
+                
+                return res1;
+            }
+            
+            FS_INLINE static float32v Floor_f32(float32v a)
+            {
+                static const float32x4_t zerox = vdupq_n_f32( 0 );
+                static const float32x4_t min1 = vreinterpretq_u32_f32( a );
+
+                float32x4_t ifl = IntFloor_f32(a);
+
+                uint32x4_t cmpmask = vcltq_f32(a, zerox);
+                float32x4_t addx = vcvtq_f32_s32( vreinterpretq_s32_u32(cmpmask) );
+
+                float32x4_t ret0 = vaddq_f32(ifl, addx);
+
+                return ret0;
+            }
+            FS_INLINE static float32v Ceil_f32(float32v a)
+            {
+                static const float32x4_t zerox = vdupq_n_f32( 0 );
+                static const float32x4_t min1 = vreinterpretq_u32_f32( a );
+
+                float32x4_t ifl = IntFloor_f32(a);
+
+                uint32x4_t cmpmask = vcgeq_f32(a, zerox);
+                float32x4_t addx = vcvtq_f32_s32( vreinterpretq_s32_u32(cmpmask) );
+
+                float32x4_t ret0 = vsubq_f32(ifl, addx);
+
+                return ret0;
+            }
+            FS_INLINE static float32v Round_f32(float32v a)
+            {
+                static const float32x4_t halfx = vdupq_n_f32( 0.5f );
+
+                return Floor_f32( vaddq_f32( a, halfx ) );
+            }
+            
+            FS_INLINE static float32v Sqrt_f32( float32v a )
+            {
+                return Reciprocal_f32(InvSqrt_f32(a));
+            }
+        
+        #else
+            FS_INLINE static float32v Floor_f32( float32v a )
+            {
+                return vrndmq_f32( a );
+            }
+            FS_INLINE static float32v Ceil_f32( float32v a )
+            {
+                return vrndpq_f32( a );
+            }
+            FS_INLINE static float32v Round_f32( float32v a )
+            {
+                return vrndnq_f32( a );
+            }
+            FS_INLINE static float32v Sqrt_f32( float32v a )
+            {
+                return vsqrtq_f32( a );
+            }
+        #endif
+        
+        
+
+        // Mask
+
+        FS_INLINE static int32v Mask_i32( int32v a, mask32v m )
+        {
+            return a & m;
+        }
+        FS_INLINE static int32v NMask_i32( int32v a, mask32v m )
+        {
+            return BitwiseAndNot_i32(a, m);
+        }
+
+        FS_INLINE static float32v Mask_f32( float32v a, mask32v m )
+        {
+            return BitwiseAnd_f32( a, vreinterpretq_f32_s32( m ) );
+        }
+        FS_INLINE static float32v NMask_f32( float32v a, mask32v m )
+        {
+            return BitwiseAndNot_f32( a, vreinterpretq_f32_s32( m ) );
+        }
+        
+        FS_INLINE static float Extract0_f32( float32v a )
+        {
+            return vgetq_lane_f32(a, 0);
+        }
+        FS_INLINE static int32_t Extract0_i32( int32v a )
+        {
+            return vgetq_lane_s32(a, 0);
+        }
+        FS_INLINE static float32v Reciprocal_f32( float32v a )
+        {
+            
+//             float32x4_t reciprocal = vrecpeq_f32( a );
+//             reciprocal = vmulq_f32( vrecpsq_f32( a, reciprocal ), reciprocal );
+//             reciprocal = vmulq_f32( vrecpsq_f32( a, reciprocal ), reciprocal );
+//             return reciprocal;
+            
+            
+            return vrecpeq_f32( a );
+        }
+        FS_INLINE static float32v BitwiseShiftRightZX_f32( float32v a, int32_t b )
+        {
+            int32x4_t rhs2 = vdupq_n_s32( -b );
+            return vreinterpretq_f32_u32 ( vreinterpretq_u32_f32 ( vshlq_u32( a, rhs2) ) );
+        }
+        
+        FS_INLINE static int32v BitwiseShiftRightZX_i32( int32v a, int32_t b )
+        {
+            int32x4_t rhs2 = vdupq_n_s32( -b );
+            return vshlq_u32( a, rhs2);
+        }
+        FS_INLINE static bool AnyMask_bool( mask32v m )
+        {
+            uint32x2_t tmp = vorr_u32(vget_low_u32(m), vget_high_u32(m));
+            return vget_lane_u32(vpmax_u32(tmp, tmp), 0);
+        }
+    };
+    
 #if FASTSIMD_COMPILE_NEON
-typedef FastSIMD_SSE_T<FastSIMD::ELevel_NEON> FastSIMD_NEON;
+    typedef NEON_T<Level_NEON> NEON;
 #endif
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,12 +45,26 @@ add_executable(FastSIMDTest
     "SIMDUnitTest.cpp"
 )
 
-if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+if(NOT FASTSIMD_COMPILE_ARM)
+
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
     set_source_files_properties("SIMDUnitTest.cpp" PROPERTIES COMPILE_FLAGS "/arch:AVX512")
 
-elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-    set_source_files_properties("SIMDUnitTest.cpp" PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512dq -mavx2 -mfma -msse4.2")
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+        set_source_files_properties("SIMDUnitTest.cpp" PROPERTIES COMPILE_FLAGS "-mavx512f -mavx512dq -mavx2 -mfma -msse4.2")
+    endif()
+
+elseif(FASTSIMD_COMPILE_ARMV7)
+
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
+    set_source_files_properties("SIMDUnitTest.cpp" PROPERTIES COMPILE_FLAGS "/arch:NEON")
+
+    elseif("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" OR "${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
+        set_source_files_properties("SIMDUnitTest.cpp" PROPERTIES COMPILE_FLAGS "-march=armv7-a -mfpu=neon")
+    endif()
 endif()
+
+
 
 target_link_libraries(FastSIMDTest
     FastNoise

--- a/tests/SIMDUnitTest.cpp
+++ b/tests/SIMDUnitTest.cpp
@@ -40,14 +40,16 @@ struct SIMDClassContainer<HEAD, TAIL...>
 };
 
 typedef SIMDClassContainer<
-    FastSIMD::Scalar,
+    FastSIMD::Scalar
 #if FASTSIMD_x86
+    ,
     FastSIMD::SSE2,
     FastSIMD::SSE41,
     FastSIMD::AVX2,
     FastSIMD::AVX512
 #endif
 #if FASTSIMD_ARM
+    ,
     FastSIMD::NEON
 #endif
 >

--- a/tests/SIMDUnitTest.cpp
+++ b/tests/SIMDUnitTest.cpp
@@ -41,10 +41,15 @@ struct SIMDClassContainer<HEAD, TAIL...>
 
 typedef SIMDClassContainer<
     FastSIMD::Scalar,
+#if FASTSIMD_x86
     FastSIMD::SSE2,
     FastSIMD::SSE41,
     FastSIMD::AVX2,
     FastSIMD::AVX512
+#endif
+#if FASTSIMD_ARM
+    FastSIMD::NEON
+#endif
 >
 SIMDClassList;
 


### PR DESCRIPTION
ARM NEON support for armv7a and aarch64 tested on qemu-user(both armv7a and aarch64) and android (aarch64)  for simplex, perlin and value noise with/without fBm