### PR TITLE
Remove the use of dynamic_cast in headers

### DIFF
--- a/include/FastNoise/Generators/Generator.h
+++ b/include/FastNoise/Generators/Generator.h
@@ -140,7 +140,7 @@ namespace FastNoise
 
             assert( !gen.get() || GetSIMDLevel() == gen->GetSIMDLevel() ); // Ensure that all SIMD levels match
 
-            SetSourceSIMDPtr( dynamic_cast<const Generator*>( gen.get() ), &memberVariable.simdGeneratorPtr );
+            SetSourceSIMDPtr( static_cast<const Generator*>( gen.get() ), &memberVariable.simdGeneratorPtr );
             memberVariable.base = gen;
         }
 


### PR DESCRIPTION
Allows linking with non-rtti project hopefully