### PR TITLE
Editor IPC and detachable node graph window

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,10 +3,11 @@ name: CI
 # Controls when the action will run. Triggers the workflow on push or pull request
 # events but only for the master branch
 on:
+  workflow_dispatch:
   push:
-    branches: [master,NewFastSIMD]
-  pull_request:
     branches: [master]
+  pull_request:
+    branches: [master,NewFastSIMD]
   release:
     types: [published]
 

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@
 /enc_temp_folder
 /cpm-cache
 /CMakeUserPresets.json
+
+external/

--- a/include/FastNoise/Generators/Generator.h
+++ b/include/FastNoise/Generators/Generator.h
@@ -149,7 +149,7 @@ namespace FastNoise
 
             assert( !gen.get() || GetActiveFeatureSet() == gen->GetActiveFeatureSet() ); // Ensure that all SIMD levels match
 
-            SetSourceSIMDPtr( dynamic_cast<const Generator*>( gen.get() ), &memberVariable.simdGeneratorPtr );
+            SetSourceSIMDPtr( static_cast<const Generator*>( gen.get() ), &memberVariable.simdGeneratorPtr );
             memberVariable.base = gen;
         }
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -73,7 +73,7 @@ find_package(ImGui REQUIRED SourcesMiscCpp)
 CPMAddPackage(
     NAME imnodes
     GITHUB_REPOSITORY Auburn/imnodes
-    GIT_TAG 32e2136a0f79ab96537088b8a757618a90bf8785
+    GIT_TAG 4ccaf656b09fd6b69bdac36f2532756760bd0aa3
     GIT_SUBMODULES ".github"
     EXCLUDE_FROM_ALL YES
     OPTIONS

--- a/tools/FastNoiseNodeEditor.cpp
+++ b/tools/FastNoiseNodeEditor.cpp
@@ -79,7 +79,11 @@ void FastNoiseNodeEditor::OpenStandaloneNodeGraph()
     if( pid < 0 )
 #endif
     {
-        Debug {} << "Failed to launch standalone node graph process";
+        Debug {} << "Failed to launch standalone node graph process"
+#ifdef WIN32
+            << GetLastError()
+#endif
+        ;
     }
 }
 

--- a/tools/FastNoiseNodeEditor.cpp
+++ b/tools/FastNoiseNodeEditor.cpp
@@ -1,6 +1,7 @@
 #include <sstream>
 #include <random>
 #include <cstdio>
+#include <atomic>
 
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include <imgui.h>
@@ -28,7 +29,7 @@ void FastNoiseNodeEditor::OpenStandaloneNodeGraph()
 #ifdef WIN32
     std::string startArgs = "\"";
     startArgs += mNodeEditorApp.GetExecutablePath();
-    startArgs += "\" detached";
+    startArgs += "\" -detached";
 
     STARTUPINFOA si;
     PROCESS_INFORMATION pi;
@@ -72,7 +73,7 @@ void FastNoiseNodeEditor::OpenStandaloneNodeGraph()
     {
         // Child process
         const char* executable = mNodeEditorApp.GetExecutablePath().data(); // Path to the current executable
-        execl( executable, executable, "detached", (char*)NULL );
+        execl( executable, executable, "-detached", (char*)NULL );
         // If execl returns, it means it has failed
         exit( EXIT_FAILURE ); // Ensure the child process exits if execl fails
     }

--- a/tools/FastNoiseNodeEditor.cpp
+++ b/tools/FastNoiseNodeEditor.cpp
@@ -692,6 +692,15 @@ void FastNoiseNodeEditor::DoNodeBenchmarks()
 
 void FastNoiseNodeEditor::Draw( const Matrix4& transformation, const Matrix4& projection, const Vector3& cameraPosition )
 {
+#ifndef WIN32
+    static pid_t parentPid = getppid();
+
+    if( getppid() != parentPid ) 
+    {
+        mNodeEditorApp.exit();
+    }
+#endif
+
     DoIpcPolling();
 
     bool isDetachedNodeEditor = mNodeEditorApp.IsDetachedNodeGraph();

--- a/tools/FastNoiseNodeEditor.h
+++ b/tools/FastNoiseNodeEditor.h
@@ -31,6 +31,7 @@ namespace Magnum
         void DoIpcPolling();
 
         static void* SetupSharedMemoryIpc();
+        static void ReleaseSharedMemoryIpc();
 
     private:
         struct Node

--- a/tools/FastNoiseNodeEditor.h
+++ b/tools/FastNoiseNodeEditor.h
@@ -18,12 +18,19 @@
 
 namespace Magnum
 {
+    class NodeEditorApp;
+
     class FastNoiseNodeEditor
     {
     public:
-        FastNoiseNodeEditor();
+        FastNoiseNodeEditor( NodeEditorApp* nodeEditorApp );
+        ~FastNoiseNodeEditor();
+
         void Draw( const Matrix4& transformation, const Matrix4& projection, const Vector3& cameraPosition );
         void SetSIMDLevel( FastSIMD::FeatureSet lvl );
+        void DoIpcPolling();
+
+        static uintptr_t SetupIpcSocket();
 
     private:
         struct Node
@@ -104,17 +111,20 @@ namespace Magnum
         FastNoise::OutputMinMax GenerateNodePreviewNoise( FastNoise::Generator* gen, float* noise );
         Node* FindNodeFromId( int id );
         int GetFreeNodeId();
-        void SetPreviewGenerator( std::string_view encodedNodeTree );
+        void SetPreviewGenerator( std::string_view encodedNodeTree, bool force = false );
         void ChangeSelectedNode( FastNoise::NodeData* newId );
         void DeleteNode( FastNoise::NodeData* nodeData );
         void DoNodeBenchmarks();
         void SetupSettingsHandlers();
+        void OpenStandaloneNodeGraph();
 
         void CheckLinks();
         void DoHelp();
         void DoContextMenu();
         void DoNodes();
         void UpdateSelected();
+
+        NodeEditorApp* mNodeEditorApp;
 
         std::unordered_map<FastNoise::NodeData*, Node> mNodes;
         FastNoise::NodeData* mDroppedLinkNode = nullptr;
@@ -124,11 +134,12 @@ namespace Magnum
         std::vector<std::unique_ptr<MetadataMenu>> mContextMetadata;
         std::string mImportNodeString;
         bool mImportNodeModal = false;
+        bool mSettingsDirty = false;
 
-        uintptr_t mSocket;
         MeshNoisePreview mMeshNoisePreview;
         NoiseTexture mNoiseTexture;
 
+        std::string mCachedSelectedEnt;
         FastNoise::NodeData* mSelectedNode = nullptr;
         Node mOverheadNode;
         int32_t mNodeBenchmarkIndex = 0;

--- a/tools/FastNoiseNodeEditor.h
+++ b/tools/FastNoiseNodeEditor.h
@@ -100,10 +100,11 @@ namespace Magnum
 
         Node& AddNode( ImVec2 startPos, const FastNoise::Metadata* metadata, bool generatePreview = true );
         bool AddNodeFromEncodedString( const char* string, ImVec2 nodePos );
-        FastNoise::SmartNode<> GenerateSelectedPreview();
+        std::string_view GetSelectedEncodedNodeTree();
         FastNoise::OutputMinMax GenerateNodePreviewNoise( FastNoise::Generator* gen, float* noise );
         Node* FindNodeFromId( int id );
         int GetFreeNodeId();
+        void SetPreviewGenerator( std::string_view encodedNodeTree );
         void ChangeSelectedNode( FastNoise::NodeData* newId );
         void DeleteNode( FastNoise::NodeData* nodeData );
         void DoNodeBenchmarks();
@@ -124,6 +125,7 @@ namespace Magnum
         std::string mImportNodeString;
         bool mImportNodeModal = false;
 
+        uintptr_t mSocket;
         MeshNoisePreview mMeshNoisePreview;
         NoiseTexture mNoiseTexture;
 

--- a/tools/FastNoiseNodeEditor.h
+++ b/tools/FastNoiseNodeEditor.h
@@ -23,14 +23,14 @@ namespace Magnum
     class FastNoiseNodeEditor
     {
     public:
-        FastNoiseNodeEditor( NodeEditorApp* nodeEditorApp );
+        FastNoiseNodeEditor( NodeEditorApp& nodeEditorApp );
         ~FastNoiseNodeEditor();
 
         void Draw( const Matrix4& transformation, const Matrix4& projection, const Vector3& cameraPosition );
         void SetSIMDLevel( FastSIMD::FeatureSet lvl );
         void DoIpcPolling();
 
-        static uintptr_t SetupIpcSocket();
+        static void* SetupSharedMemoryIpc();
 
     private:
         struct Node
@@ -111,7 +111,7 @@ namespace Magnum
         FastNoise::OutputMinMax GenerateNodePreviewNoise( FastNoise::Generator* gen, float* noise );
         Node* FindNodeFromId( int id );
         int GetFreeNodeId();
-        void SetPreviewGenerator( std::string_view encodedNodeTree, bool force = false );
+        void SetPreviewGenerator( std::string_view encodedNodeTree );
         void ChangeSelectedNode( FastNoise::NodeData* newId );
         void DeleteNode( FastNoise::NodeData* nodeData );
         void DoNodeBenchmarks();
@@ -124,7 +124,7 @@ namespace Magnum
         void DoNodes();
         void UpdateSelected();
 
-        NodeEditorApp* mNodeEditorApp;
+        NodeEditorApp& mNodeEditorApp;
 
         std::unordered_map<FastNoise::NodeData*, Node> mNodes;
         FastNoise::NodeData* mDroppedLinkNode = nullptr;
@@ -139,7 +139,7 @@ namespace Magnum
         MeshNoisePreview mMeshNoisePreview;
         NoiseTexture mNoiseTexture;
 
-        std::string mCachedSelectedEnt;
+        std::string mCachedActiveEnt;
         FastNoise::NodeData* mSelectedNode = nullptr;
         Node mOverheadNode;
         int32_t mNodeBenchmarkIndex = 0;

--- a/tools/NodeEditorApp.cpp
+++ b/tools/NodeEditorApp.cpp
@@ -24,14 +24,18 @@ void InitResources()
 NodeEditorApp::NodeEditorApp( const Arguments& arguments ) :
     Platform::Application{ arguments,
     Configuration{}
-    .setTitle( "FastNoise2 Node Editor" )
+    .setTitle( arguments.argc > 1 ? "FastNoise2 Node Graph" : "FastNoise2 Node Editor" )
     .setSize( Vector2i( 1280, 720 ) )
-    .setWindowFlags( Configuration::WindowFlag::Resizable | Configuration::WindowFlag::Maximized ),
+    .setWindowFlags( Configuration::WindowFlag::Resizable | (arguments.argc > 1 ? (Configuration::WindowFlag)0 : Configuration::WindowFlag::Maximized ) ),
     GLConfiguration{}
     .setSampleCount( 4 )
     },
+    mIsDetachedNodeGraph( arguments.argc > 1 ),
+    mExecutablePath( arguments.argv[0] ),
+    mIpcSocket( FastNoiseNodeEditor::SetupIpcSocket() ),
     mImGuiIntegrationContext{ NoCreate },
-    mImGuiContext{ ImGui::CreateContext() }
+    mImGuiContext{ ImGui::CreateContext() },
+    mNodeEditor( this )
 {
     InitResources();
 
@@ -96,74 +100,77 @@ void NodeEditorApp::drawEvent()
     else if( !ImGui::GetIO().WantTextInput && isTextInputActive() )
         stopTextInput();
 
+    if( !mIsDetachedNodeGraph )
     {
-        if( ImGui::Button( "Reset State" ) )
         {
-            ImGui::ClearIniSettings();
-            mNodeEditor.~FastNoiseNodeEditor();
-            new( &mNodeEditor ) FastNoiseNodeEditor();
-            ImGui::SaveIniSettingsToDisk( ImGui::GetIO().IniFilename );
+            if( ImGui::Button( "Reset State" ) )
+            {
+                ImGui::ClearIniSettings();
+                mNodeEditor.~FastNoiseNodeEditor();
+                new( &mNodeEditor ) FastNoiseNodeEditor( this );
+                ImGui::SaveIniSettingsToDisk( ImGui::GetIO().IniFilename );
+            }
+
+            if( ImGui::ColorEdit3( "Clear Color", mClearColor.data() ) )
+                GL::Renderer::setClearColor( mClearColor );
+
+            ImGui::Checkbox( "Backface Culling", &mBackFaceCulling );
+
+            ImGui::Text( "Application average %.3f ms/frame (%.1f FPS)",
+                         1000.0 / Double( ImGui::GetIO().Framerate ), Double( ImGui::GetIO().Framerate ) );
+
+            if( ImGui::Combo( "Max Feature Set", &mMaxFeatureSet, mFeatureSetNames.data(), (int)mFeatureSetSelection.size() ) ||
+                ImGuiExtra::ScrollCombo( &mMaxFeatureSet, (int)mFeatureSetSelection.size() ) )
+            {
+                FastSIMD::FeatureSet newLevel = mFeatureSetSelection[mMaxFeatureSet];
+                mNodeEditor.SetSIMDLevel( newLevel );
+            }
         }
 
-        if( ImGui::ColorEdit3( "Clear Color", mClearColor.data() ) )
-            GL::Renderer::setClearColor( mClearColor );
-
-        ImGui::Checkbox( "Backface Culling", &mBackFaceCulling );
-
-        ImGui::Text( "Application average %.3f ms/frame (%.1f FPS)",
-            1000.0 / Double( ImGui::GetIO().Framerate ), Double( ImGui::GetIO().Framerate ) );
-
-        if( ImGui::Combo( "Max Feature Set", &mMaxFeatureSet, mFeatureSetNames.data(), (int)mFeatureSetSelection.size() ) ||
-            ImGuiExtra::ScrollCombo( &mMaxFeatureSet, (int)mFeatureSetSelection.size() ) )
-        {   
-            FastSIMD::FeatureSet newLevel = mFeatureSetSelection[mMaxFeatureSet];
-            mNodeEditor.SetSIMDLevel( newLevel );
+        // Update camera pos
+        Vector3 cameraVelocity( 0 );
+        if( mKeyDown[Key_W] || mKeyDown[Key_Up] )
+        {
+            cameraVelocity.z() -= 1.0f;
         }
-    }
+        if( mKeyDown[Key_S] || mKeyDown[Key_Down] )
+        {
+            cameraVelocity.z() += 1.0f;
+        }
+        if( mKeyDown[Key_A] || mKeyDown[Key_Left] )
+        {
+            cameraVelocity.x() -= 1.0f;
+        }
+        if( mKeyDown[Key_D] || mKeyDown[Key_Right] )
+        {
+            cameraVelocity.x() += 1.0f;
+        }
+        if( mKeyDown[Key_Q] || mKeyDown[Key_PgDn] )
+        {
+            cameraVelocity.y() -= 1.0f;
+        }
+        if( mKeyDown[Key_E] || mKeyDown[Key_PgUp] )
+        {
+            cameraVelocity.y() += 1.0f;
+        }
+        if( mKeyDown[Key_RShift] || mKeyDown[Key_LShift] )
+        {
+            cameraVelocity *= 4.0f;
+        }
 
-    // Update camera pos
-    Vector3 cameraVelocity( 0 );
-    if( mKeyDown[Key_W] || mKeyDown[Key_Up] )
-    {
-        cameraVelocity.z() -= 1.0f;
-    }
-    if( mKeyDown[Key_S] || mKeyDown[Key_Down] )
-    {
-        cameraVelocity.z() += 1.0f;
-    }
-    if( mKeyDown[Key_A] || mKeyDown[Key_Left] )
-    {
-        cameraVelocity.x() -= 1.0f;
-    }
-    if( mKeyDown[Key_D] || mKeyDown[Key_Right] )
-    {
-        cameraVelocity.x() += 1.0f;
-    }
-    if( mKeyDown[Key_Q] || mKeyDown[Key_PgDn] )
-    {
-        cameraVelocity.y() -= 1.0f;
-    }
-    if( mKeyDown[Key_E] || mKeyDown[Key_PgUp] )
-    {
-        cameraVelocity.y() += 1.0f;
-    }
-    if( mKeyDown[Key_RShift] || mKeyDown[Key_LShift] )
-    {
-        cameraVelocity *= 4.0f;
-    }
+        cameraVelocity *= mFrameTime.previousFrameDuration() * 80.0f;
 
-    cameraVelocity *= mFrameTime.previousFrameDuration() * 80.0f;
+        if( !cameraVelocity.isZero() )
+        {
+            Matrix4 transform = mCameraObject.transformation();
+            transform.translation() += transform.rotation() * cameraVelocity;
+            mCameraObject.setTransformation( transform );
+        }
 
-    if( !cameraVelocity.isZero() ) 
-    {
-        Matrix4 transform = mCameraObject.transformation();
-        transform.translation() += transform.rotation() * cameraVelocity;
-        mCameraObject.setTransformation( transform );
-    }
-
-    if( mBackFaceCulling )
-    {
-        GL::Renderer::enable( GL::Renderer::Feature::FaceCulling );
+        if( mBackFaceCulling )
+        {
+            GL::Renderer::enable( GL::Renderer::Feature::FaceCulling );
+        }
     }
 
     mNodeEditor.Draw( mCamera.cameraMatrix(), mCamera.projectionMatrix(), mCameraObject.transformation().translation() );

--- a/tools/NodeEditorApp.cpp
+++ b/tools/NodeEditorApp.cpp
@@ -21,16 +21,21 @@ void InitResources()
 #endif
 }
 
+static bool IsDetached( const NodeEditorApp::Arguments& arguments )
+{
+    return arguments.argc > 1 && std::string_view { arguments.argv[1] } == "-detached";
+}
+
 NodeEditorApp::NodeEditorApp( const Arguments& arguments ) :
     Platform::Application{ arguments,
-    Configuration{}
-    .setTitle( arguments.argc > 1 ? "FastNoise2 Node Graph" : "FastNoise2 Node Editor" )
-    .setSize( Vector2i( 1280, 720 ) )
-    .setWindowFlags( Configuration::WindowFlag::Resizable | (arguments.argc > 1 ? (Configuration::WindowFlag)0 : Configuration::WindowFlag::Maximized ) ),
-    GLConfiguration{}
-    .setSampleCount( 4 )
+        Configuration{}
+        .setTitle( IsDetached( arguments ) ? "FastNoise2 Node Graph" : "FastNoise2 Node Editor" )
+        .setSize( Vector2i( 1280, 720 ) )
+        .setWindowFlags( Configuration::WindowFlag::Resizable | ( IsDetached( arguments ) ? (Configuration::WindowFlag)0 : Configuration::WindowFlag::Maximized ) ),
+        GLConfiguration{}
+        .setSampleCount( 4 )
     },
-    mIsDetachedNodeGraph( arguments.argc > 1 ),
+    mIsDetachedNodeGraph( IsDetached( arguments ) ),
     mExecutablePath( arguments.argv[0] ),
     mIpcSharedMemory( FastNoiseNodeEditor::SetupSharedMemoryIpc() ),
     mImGuiIntegrationContext{ NoCreate },

--- a/tools/NodeEditorApp.cpp
+++ b/tools/NodeEditorApp.cpp
@@ -86,6 +86,8 @@ NodeEditorApp::~NodeEditorApp()
     // Avoid trying to save settings after node editor is already destroyed
     ImGui::SaveIniSettingsToDisk( ImGui::GetIO().IniFilename );
     ImGui::GetIO().IniFilename = nullptr;
+
+    FastNoiseNodeEditor::ReleaseSharedMemoryIpc();
 }
 
 void NodeEditorApp::drawEvent()

--- a/tools/NodeEditorApp.cpp
+++ b/tools/NodeEditorApp.cpp
@@ -32,10 +32,10 @@ NodeEditorApp::NodeEditorApp( const Arguments& arguments ) :
     },
     mIsDetachedNodeGraph( arguments.argc > 1 ),
     mExecutablePath( arguments.argv[0] ),
-    mIpcSocket( FastNoiseNodeEditor::SetupIpcSocket() ),
+    mIpcSharedMemory( FastNoiseNodeEditor::SetupSharedMemoryIpc() ),
     mImGuiIntegrationContext{ NoCreate },
     mImGuiContext{ ImGui::CreateContext() },
-    mNodeEditor( this )
+    mNodeEditor( *this )
 {
     InitResources();
 
@@ -107,7 +107,7 @@ void NodeEditorApp::drawEvent()
             {
                 ImGui::ClearIniSettings();
                 mNodeEditor.~FastNoiseNodeEditor();
-                new( &mNodeEditor ) FastNoiseNodeEditor( this );
+                new( &mNodeEditor ) FastNoiseNodeEditor( *this );
                 ImGui::SaveIniSettingsToDisk( ImGui::GetIO().IniFilename );
             }
 

--- a/tools/NodeEditorApp.h
+++ b/tools/NodeEditorApp.h
@@ -18,6 +18,21 @@ namespace Magnum
         explicit NodeEditorApp( const Arguments& arguments );
         ~NodeEditorApp();
 
+        bool IsDetachedNodeGraph()
+        {
+            return mIsDetachedNodeGraph;
+        }
+
+        uintptr_t GetIpcSocket()
+        {
+            return mIpcSocket;
+        }
+
+        std::string_view GetExecutablePath()
+        {
+            return mExecutablePath;
+        }
+
     private:
         void drawEvent() override;
         void viewportEvent( ViewportEvent& event ) override;
@@ -32,6 +47,10 @@ namespace Magnum
 
         void UpdatePespectiveProjection();
         void HandleKeyEvent( KeyEvent::Key key, bool value );
+
+        bool mIsDetachedNodeGraph;
+        std::string mExecutablePath;
+        uintptr_t mIpcSocket;
 
         SceneGraph::Object<SceneGraph::MatrixTransformation3D> mCameraObject;
         SceneGraph::Camera3D mCamera{ mCameraObject };

--- a/tools/NodeEditorApp.h
+++ b/tools/NodeEditorApp.h
@@ -23,9 +23,9 @@ namespace Magnum
             return mIsDetachedNodeGraph;
         }
 
-        uintptr_t GetIpcSocket()
+        void* GetIpcSharedMemory()
         {
-            return mIpcSocket;
+            return mIpcSharedMemory;
         }
 
         std::string_view GetExecutablePath()
@@ -50,7 +50,7 @@ namespace Magnum
 
         bool mIsDetachedNodeGraph;
         std::string mExecutablePath;
-        uintptr_t mIpcSocket;
+        void* mIpcSharedMemory;
 
         SceneGraph::Object<SceneGraph::MatrixTransformation3D> mCameraObject;
         SceneGraph::Camera3D mCamera{ mCameraObject };

--- a/tools/SharedMemoryIpc.inl
+++ b/tools/SharedMemoryIpc.inl
@@ -9,7 +9,7 @@
 #include <unistd.h>
 #endif
 
-static constexpr const char* kSharedMemoryName = "FastNoise2NodeEditor";
+static constexpr const char* kSharedMemoryName = "/FastNoise2NodeEditor";
 static constexpr unsigned int kSharedMemorySize = 64 * 1024;
 
 // Setup shared memory for IPC selected node ENT updates
@@ -56,8 +56,11 @@ void* FastNoiseNodeEditor::SetupSharedMemoryIpc()
     // Configure the size of the shared memory object
     if( ftruncate( shmFd, kSharedMemorySize ) == -1 )
     {
-        Debug {} << "Failed to config IPC shared memory object";
-        return nullptr;
+        if( errno != EINVAL ) // If the error is not just because it's already the right size
+        {
+            Debug {} << "Failed to config IPC shared memory object";
+            return nullptr;
+        }
     }
 
     // Memory map the shared memory object

--- a/tools/SharedMemoryIpc.inl
+++ b/tools/SharedMemoryIpc.inl
@@ -1,0 +1,114 @@
+#ifdef _WIN32
+#define NOMINMAX
+#define WIN32_LEAN_AND_MEAN
+#include <Windows.h>
+#else
+#include <fcntl.h> // For O_* constants
+#include <sys/mman.h> // For shared memory
+#include <sys/stat.h> // For mode constants
+#include <unistd.h>
+#endif
+
+static constexpr const char* kSharedMemoryName = "FastNoise2NodeEditor";
+static constexpr unsigned int kSharedMemorySize = 64 * 1024;
+
+// Setup shared memory for IPC selected node ENT updates
+void* FastNoiseNodeEditor::SetupSharedMemoryIpc()
+{
+#ifdef WIN32
+    // Create a shared memory file mapping
+    HANDLE hMapFile = CreateFileMapping(
+        INVALID_HANDLE_VALUE, // Use paging file - shared memory
+        NULL, // Default security attributes
+        PAGE_READWRITE, // Read/write access
+        0, // Maximum object size (high-order DWORD)
+        kSharedMemorySize, // Maximum object size (low-order DWORD)
+        kSharedMemoryName ); // Name of mapping object
+
+    if( hMapFile == NULL )
+    {
+        Debug {} << "Failed to create IPC shared memory object" << GetLastError();
+        return nullptr;
+    }
+
+    // Map a view of the file mapping into the address space of the current process
+    void* ptr = MapViewOfFile( hMapFile, // Handle to map object
+        FILE_MAP_ALL_ACCESS, // Read/write permission
+        0,
+        0,
+        kSharedMemorySize );
+
+    if( !ptr )
+    {
+        Debug {} << "Failed to map IPC shared memory" << GetLastError();
+    }
+    return ptr;
+
+#else
+    // Create the shared memory object
+    int shmFd = shm_open( kSharedMemoryName, O_CREAT | O_RDWR, 0666 );
+    if( shmFd == -1 )
+    {
+        Debug {} << "Failed to create IPC shared memory object";
+        return nullptr;
+    }
+
+    // Configure the size of the shared memory object
+    if( ftruncate( shmFd, kSharedMemorySize ) == -1 )
+    {
+        Debug {} << "Failed to config IPC shared memory object";
+        return nullptr;
+    }
+
+    // Memory map the shared memory object
+    void* ptr = mmap( 0, kSharedMemorySize, PROT_READ | PROT_WRITE, MAP_SHARED, shmFd, 0 );
+    if( ptr == MAP_FAILED )
+    {
+        Debug {} << "Failed to map IPC shared memory object";
+        return nullptr;
+    }
+    return ptr;
+#endif
+}
+
+void FastNoiseNodeEditor::ReleaseSharedMemoryIpc()
+{
+#ifndef WIN32
+    shm_unlink( kSharedMemoryName );
+#endif
+}
+
+// Poll for changes in the shared memory space
+void FastNoiseNodeEditor::DoIpcPolling()
+{
+    const void* sharedMemory = mNodeEditorApp.GetIpcSharedMemory();
+
+    if( sharedMemory )
+    {
+        const unsigned char sharedCounter = *static_cast<const unsigned char*>( sharedMemory );
+        const unsigned char dataType = *( static_cast<const unsigned char*>( sharedMemory ) + 1 );
+
+        // Invalidate the counter to read initial stale data only if it's type 0
+        static int counter = ( dataType == 0 ) ? 0xFFFFFF : sharedCounter;
+
+        if( sharedCounter != counter )
+        {
+            counter = sharedCounter;
+
+            // Check type
+            switch( dataType )
+            {
+            default:
+                Debug {} << "Unknown IPC data type" << dataType;
+                break;
+            case 0: // Selected node ENT
+            {
+                std::string newEncodedNodeTree = static_cast<const char*>( sharedMemory ) + 2;
+
+                SetPreviewGenerator( newEncodedNodeTree );
+            }
+            break;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds IPC via shared memory to send selected node ENT between different processes.

Allows a second instance of the node editor to be launched and used as a fullscreen node graph to control the main preview window (added button in UI to detach node graph)

The IPC code in `tools/SharedMemoryIpc.inl` can be copied to add IPC to your own project to make use of the node editor's UI to control node trees in your engine in realtime

I have not tested this on desktop Linux or MacOS, if anyone has access to test it would be much appreciated!

#59 

![image](https://github.com/Auburn/FastNoise2/assets/1349548/bbe458df-8b36-407f-989f-c8a82293d4ac)
