### PR TITLE
Add a link to Rust bindings in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Bindings:
 - [C#](https://github.com/Auburn/FastNoise2Bindings)
 - [Unreal Engine CMake](https://github.com/caseymcc/UE4_FastNoise2)
 - [Unreal Engine Blueprint](https://github.com/DoubleDeez/UnrealFastNoise2)
+- [Rust](https://github.com/Lemonzyy/fastnoise2-rs)
 
 Roadmap:
 - [Vague collection of ideas](https://github.com/users/Auburn/projects/1)


### PR DESCRIPTION
With the Rust bindings, you can create a node from an encoded node tree and also using the metadata system (thanks to you for the C# bindings as a reference).