### PR TITLE
CMake version bump to 3.13

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMakeList.txt : CMake project for FastNoise2
-cmake_minimum_required(VERSION 3.7.1)
+cmake_minimum_required(VERSION 3.13)
 
 project(FastNoise2 VERSION 0.10.0)
 set(CMAKE_CXX_STANDARD 17)


### PR DESCRIPTION
Starting from CMake 3.13 the `option()` command honors normal variables.
https://cmake.org/cmake/help/latest/policy/CMP0077.html
This makes setting Luau options easier when including Luau with `add_subdirectory()`.
Setting options before 3.13:
```cmake
set(FASTNOISE_OPTION ON/OFF CACHE BOOL "Description of option" FORCE)
```
Setting options after 3.13:
```
set(FASTNOISE_OPTION ON/OFF)
```
The later is way less obscure.